### PR TITLE
Add direct execution entrypoint

### DIFF
--- a/arb_calculator.py
+++ b/arb_calculator.py
@@ -267,4 +267,8 @@ async def run_cycle():
         if 'redis_client' in locals() and redis_client:
             await redis_client.close()
         if 'pg_pool' in locals() and pg_pool:
-            await pg_pool.close() 
+            await pg_pool.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(run_cycle())


### PR DESCRIPTION
## Summary
- run the scan cycle when `arb_calculator.py` is executed directly

## Testing
- `python -m py_compile arb_calculator.py odds_fetcher.py`
- `python arb_calculator.py` *(fails: Missing required env vars)*

------
https://chatgpt.com/codex/tasks/task_e_687d55a3ecc883259f5d9323ef2a6cf9